### PR TITLE
Fix:本の寄贈者とISBNコードをDBに保存&同じ本は登録できないよう修正

### DIFF
--- a/pages/api/books/store.ts
+++ b/pages/api/books/store.ts
@@ -14,13 +14,13 @@ export default async function storeBook(
   const { code, donor, userId } = req.body;
   const donorValue = donor || "office";
 
-  const isExistingBook = await prisma.book.findUnique({
+  const ExistingBook = await prisma.book.findUnique({
     where: {
       bookCode: code,
     },
   });
 
-  if (isExistingBook) {
+  if (ExistingBook) {
     return res.status(409).json({ message: "同じ本が既に存在します" });
   }
 

--- a/pages/api/books/store.ts
+++ b/pages/api/books/store.ts
@@ -1,4 +1,3 @@
-import { PrismaClient } from "@prisma/client";
 import { NextApiRequest, NextApiResponse } from "next";
 import prisma from "@/lib/prisma";
 
@@ -12,7 +11,19 @@ export default async function storeBook(
     return res.status(405).json({ message: "Method Not Allowed" });
   }
 
-  const { code, userId } = req.body;
+  const { code, donor, userId } = req.body;
+  const donorValue = donor || "office";
+
+  const isExistingBook = await prisma.book.findUnique({
+    where: {
+      bookCode: code,
+    },
+  });
+
+  if (isExistingBook) {
+    return res.status(409).json({ message: "同じ本が既に存在します" });
+  }
+
   const url = `${googleBooksUrl}${code}`;
   const response = await fetch(url);
   const bookData = await response.json();
@@ -26,16 +37,20 @@ export default async function storeBook(
           author: item.authors[0],
           description: item.description,
           imageLink: item.imageLinks?.thumbnail,
+          bookCode: code,
+          donor: donorValue,
           userId: userId,
           publishedDate: item.publishedDate,
         },
       });
-      return res.status(200).json({ message: "Book saved successfully", book });
+      return res
+        .status(200)
+        .json({ message: "本の登録に成功しました！", book });
     } catch (err) {
       console.error("Error saving the book:", err);
-      return res.status(500).json({ message: "Failed to save the book" });
+      return res.status(500).json({ message: "本の登録に失敗しました..." });
     }
   } else {
-    return res.status(404).json({ message: "Book not found" });
+    return res.status(404).json({ message: "本が存在しないです" });
   }
 }

--- a/pages/api/fetchData.ts
+++ b/pages/api/fetchData.ts
@@ -11,5 +11,10 @@ export const fetchData = async (url: string, method: string, data?: any) => {
   }
 
   const response = await fetch(url, options);
-  return response.json();
+  const responseData = await response.json();
+
+  return {
+    ok: response.ok,
+    data: responseData,
+  };
 };

--- a/pages/books/[id].tsx
+++ b/pages/books/[id].tsx
@@ -17,7 +17,8 @@ const BookPage = () => {
   useEffect(() => {
     // 仮のAPIから本のデータを取得する例
     const getBookDetail = async () => {
-      const bookDetail = await fetchData(`/api/books/${id}`, "GET");
+      const response = await fetchData(`/api/books/${id}`, "GET");
+      const bookDetail = response.data;
       setBook(bookDetail);
     };
     getBookDetail();

--- a/pages/books/store.tsx
+++ b/pages/books/store.tsx
@@ -1,27 +1,27 @@
 import { useSession } from "next-auth/react";
 import React, { useState } from "react";
-import { toast } from 'react-toastify'
+import { toast } from "react-toastify";
+import { fetchData } from "../api/fetchData";
 
 const Store = () => {
-  const { data: session, status } = useSession();
+  const { data: session } = useSession();
   const [code, setCode] = useState("");
+  const [donor, setDonor] = useState("");
+
   const storeBook = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const response = await fetch("/api/books/store", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ code, userId: session?.user.id }),
+    const response = await fetchData("/api/books/store", "POST", {
+      code,
+      donor,
+      userId: session?.user.id,
     });
 
     if (response.ok) {
-      toast.success('本の登録に成功しました！')
+      toast.success(response.data.message);
       setCode("");
-      console.log("Book saved successfully");
+      setDonor("");
     } else {
-      toast.error('本の登録に失敗しました、、、')
-      console.error("Failed to save the book");
+      toast.error(response.data.message);
     }
   };
   return (
@@ -31,8 +31,17 @@ const Store = () => {
           className="h-24 p-2 border border-gray-300 rounded resize-none focus:outline-none focus:ring-2 focus:ring-blue-400"
           placeholder="ISBNコードを入力してください。"
           onChange={(e) => setCode(e.target.value)}
+          required
           value={code}
         />
+        <br />
+        <input
+          className="h-24 p-2 border border-gray-300 rounded resize-none focus:outline-none focus:ring-2 focus:ring-blue-400"
+          placeholder="寄贈者の名前を入力してください"
+          onChange={(e) => setDonor(e.target.value)}
+          value={donor}
+        />
+        <br />
         <button type="submit">登録する</button>
       </form>
     </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,8 +12,9 @@ export default function Home() {
   //本の一覧を取得
   useEffect(() => {
     const getAllBooks = async () => {
-      const allbooks = await fetchData("/api/books", "GET");
-      setBooks(allbooks);
+      const response = await fetchData("/api/books", "GET");
+      const allBooks = response.data;
+      setBooks(allBooks);
     };
     getAllBooks();
   }, []);

--- a/prisma/migrations/20240518082958_add_book_code_donor_to_book/migration.sql
+++ b/prisma/migrations/20240518082958_add_book_code_donor_to_book/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - Added the required column `bookCode` to the `Book` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `donor` to the `Book` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Book" ADD COLUMN     "bookCode" TEXT NOT NULL,
+ADD COLUMN     "donor" TEXT NOT NULL;

--- a/prisma/migrations/20240518085344_add_default_value_to_donor_of_book/migration.sql
+++ b/prisma/migrations/20240518085344_add_default_value_to_donor_of_book/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Book" ALTER COLUMN "donor" SET DEFAULT 'office';

--- a/prisma/migrations/20240518094950_add_unique_book_code/migration.sql
+++ b/prisma/migrations/20240518094950_add_unique_book_code/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[bookCode]` on the table `Book` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Book_bookCode_key" ON "Book"("bookCode");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,8 @@ model Book {
   author        String
   description   String
   imageLink     String?
+  bookCode      String          @unique
+  donor         String          @default("office")
   userId        String
   user          User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   publishedDate String?


### PR DESCRIPTION
## 課題のリンク
- https://github.com/Tsune68/library-next/issues/10
- https://github.com/Tsune68/library-next/issues/11
## 改修内容
- donor(デフォルト値はoffice）とbookCode(unique)カラムを追加し、寄贈者とISBNコードを保存するように修正
- ISBNコードが同じ本を登録しようとするとエラーを返すよう修正

## キャプチャ
### 同じ本を登録した場合

https://github.com/Tsune68/library-next/assets/82308300/c4d14ff6-ec13-4110-b56a-ff9f124cc07b

### DBの画像
<img width="1116" alt="スクリーンショット 2024-05-18 20 03 27" src="https://github.com/Tsune68/library-next/assets/82308300/177a0fa1-ab1b-4651-91e4-e4afd09181c1">


## 検証内容
- 同じ本を登録した場合にエラーが出ることを目視で確認
- 寄贈者を入力しない場合、donorカラムの値が「office」になることを目視で確認

## 相談事項
